### PR TITLE
drop dependency on suse-release

### DIFF
--- a/dist/package/openSUSE-repos.spec
+++ b/dist/package/openSUSE-repos.spec
@@ -70,8 +70,6 @@ URL:            https://github.com/openSUSE/openSUSE-repos
 Source:         openSUSE-repos-%{version}.tar.xz
 #boo#1203715
 BuildRequires:  -post-build-checks
-# We're compatible with any SUSE Linux distribution
-Requires:       suse-release
 Requires:       zypper
 Conflicts:      otherproviders(openSUSE-repos)
 Provides:       openSUSE-repos


### PR DESCRIPTION
* Both SLE and Leap Micro and do not support it