### PR TITLE
Use zypp style variable for DIST_ARCH boo#1205460

### DIFF
--- a/opensuse-leap-micro-repoindex.xml
+++ b/opensuse-leap-micro-repoindex.xml
@@ -5,22 +5,22 @@
     debugenable="false"
     sourceenable="false">
 
-<repo url="%{disturl}/distribution/%{distsub}%{distver}/product/repo/Leap-Micro-%{distver}-%{DIST_ARCH}-Media1"
+<repo url="%{disturl}/distribution/%{distsub}%{distver}/product/repo/Leap-Micro-%{distver}-$DIST_ARCH-Media1"
     alias="repo-main"
     name="%{alias} (%{distver})"
     enabled="true"
     autorefresh="true"/>
 
-<repo url="%{disturl}/distribution/%{distsub}%{distver}/product/repo/Leap-Micro-%{distver}-%{DIST_ARCH}-Media2"
+<repo url="%{disturl}/distribution/%{distsub}%{distver}/product/repo/Leap-Micro-%{distver}-$DIST_ARCH-Media2"
     alias="repo-debug"
     name="%{alias} (%{distver})"
-    enabled="true"
+    enabled="false"
     autorefresh="true"/>
 
-<repo url="%{disturl}/distribution/%{distsub}%{distver}/product/repo/Leap-Micro-%{distver}-%{DIST_ARCH}-Media3"
+<repo url="%{disturl}/distribution/%{distsub}%{distver}/product/repo/Leap-Micro-%{distver}-$DIST_ARCH-Media3"
     alias="repo-source"
     name="%{alias} (%{distver})"
-    enabled="true"
+    enabled="false"
     autorefresh="true"/>
 
 <repo url="%{disturl}/update/%{distsub}%{distver}/sle"

--- a/opensuse-leap-ports-repoindex.xml
+++ b/opensuse-leap-ports-repoindex.xml
@@ -5,19 +5,19 @@
     debugenable="false"
     sourceenable="false">
 
-<repo url="%{disturl}/ports/%{DIST_ARCH}/distribution/%{distsub}%{distver}/repo/oss"
+<repo url="%{disturl}/ports/$DIST_ARCH/distribution/%{distsub}%{distver}/repo/oss"
     alias="repo-oss"
     name="%{alias} (%{distver})"
     enabled="true"
     autorefresh="true"/>
 
-<repo url="%{disturl}/ports/%{DIST_ARCH}/source/distribution/%{distsub}%{distver}/repo/oss"
+<repo url="%{disturl}/ports/$DIST_ARCH/source/distribution/%{distsub}%{distver}/repo/oss"
     alias="repo-oss-source"
     name="%{alias} (%{distver})"
     enabled="false"
     autorefresh="true"/>
 
-<repo url="%{disturl}/ports/%{DIST_ARCH}/debug/distribution/%{distsub}%{distver}/repo/oss"
+<repo url="%{disturl}/ports/$DIST_ARCH/debug/distribution/%{distsub}%{distver}/repo/oss"
     alias="repo-oss-debug"
     name="%{alias} (%{distver})"
     enabled="false"

--- a/opensuse-tumbleweed-ports-repoindex.xml
+++ b/opensuse-tumbleweed-ports-repoindex.xml
@@ -4,25 +4,25 @@
     debugenable="false"
     sourceenable="false">
 
-<repo url="%{disturl}/ports/%{DIST_ARCH}/%{distsub}/repo/oss"
+<repo url="%{disturl}/ports/$DIST_ARCH/%{distsub}/repo/oss"
     alias="repo-oss"
     name="%{alias} (%{distver})"
     enabled="true"
     autorefresh="true"/>
 
-<repo url="%{disturl}/ports/%{DIST_ARCH}/debug/%{distsub}/repo/oss"
+<repo url="%{disturl}/ports/$DIST_ARCH/debug/%{distsub}/repo/oss"
     alias="repo-oss-debug"
     name="%{alias} (%{distver})"
     enabled="true"
     autorefresh="true"/>
 
-<repo url="%{disturl}/ports/%{DIST_ARCH}/source/%{distsub}/repo/oss"
+<repo url="%{disturl}/ports/$DIST_ARCH/source/%{distsub}/repo/oss"
     alias="repo-oss-source"
     name="%{alias} (%{distver})"
     enabled="true"
     autorefresh="true"/>
 
-<repo url="%{disturl}/ports/%{DIST_ARCH}/update/%{distsub}"
+<repo url="%{disturl}/ports/$DIST_ARCH/update/%{distsub}"
     alias="update-tumbleweed"
     name="%{alias}"
     enabled="true"


### PR DESCRIPTION
Althought service file has different notation of variables, the DIST_ARCH is actually not treated as a service file var but rather as a ZYPP variable, so we have to treat it that way.