### PR TITLE
Drop obsoleting of TW from openSUSE-repos-MicroOS

### DIFF
--- a/dist/package/openSUSE-repos.spec
+++ b/dist/package/openSUSE-repos.spec
@@ -74,15 +74,12 @@ Requires:       zypper
 Conflicts:      otherproviders(openSUSE-repos)
 Provides:       openSUSE-repos
 %if "%{?theme}" == "Tumbleweed"
-# Unconditionally ensure Leap upgrades to Tumbleweed
 Obsoletes:      openSUSE-repos-Leap
 Obsoletes:      openSUSE-repos-LeapMicro
 %endif
 %if "%{?theme}" == "MicroOS"
-# Support migration from literally anything including TW to MicroOS
 Obsoletes:      openSUSE-repos-Leap
 Obsoletes:      openSUSE-repos-LeapMicro
-Obsoletes:      openSUSE-repos-Tumbleweed
 %endif
 
 %description


### PR DESCRIPTION
* This will no longer lead to replacement of openSUSE-repos-Tumbleweed on each zypper dup