### PR TITLE
openSUSE-repos adaptation of CDN

### DIFF
--- a/opensuse-leap-micro-repoindex.xml
+++ b/opensuse-leap-micro-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://download.opensuse.org"
+    disturl="https://downloadcontentcdn.opensuse.org"
     distsub="leap-micro/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap-micro-repoindex.xml
+++ b/opensuse-leap-micro-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://downloadcontentcdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="leap-micro/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap-ports-repoindex.xml
+++ b/opensuse-leap-ports-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://download.opensuse.org"
+    disturl="https://downloadcontentcdn.opensuse.org"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap-ports-repoindex.xml
+++ b/opensuse-leap-ports-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://downloadcontentcdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap-repoindex.xml
+++ b/opensuse-leap-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://download.opensuse.org"
+    disturl="https://downloadcontentcdn.opensuse.org"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap-repoindex.xml
+++ b/opensuse-leap-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://downloadcontentcdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://download.opensuse.org"
+    disturl="https://downloadcontentcdn.opensuse.org"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://downloadcontentcdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-microos-repoindex.xml
+++ b/opensuse-microos-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://downloadcontentcdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="tumbleweed/"
     debugenable="false"
     sourceenable="false">

--- a/opensuse-microos-repoindex.xml
+++ b/opensuse-microos-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://download.opensuse.org"
+    disturl="https://downloadcontentcdn.opensuse.org"
     distsub="tumbleweed/"
     debugenable="false"
     sourceenable="false">

--- a/opensuse-tumbleweed-repoindex.xml
+++ b/opensuse-tumbleweed-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://downloadcontentcdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="tumbleweed/"
     debugenable="false"
     sourceenable="false">

--- a/opensuse-tumbleweed-repoindex.xml
+++ b/opensuse-tumbleweed-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://download.opensuse.org"
+    disturl="https://downloadcontentcdn.opensuse.org"
     distsub="tumbleweed/"
     debugenable="false"
     sourceenable="false">


### PR DESCRIPTION
Let use our early adopters CDN by default

* https://code.opensuse.org/leap/features/issue/128

I did discuss it with Dirk in a private email thread. 

Original annoucement in:
https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/4YOJ2MMSET5JN42T2H2GAHQG5MG5YGBT/