### PR TITLE
NVIDIA repo addition

### DIFF
--- a/dist/package/openSUSE-repos.spec
+++ b/dist/package/openSUSE-repos.spec
@@ -1,7 +1,7 @@
 #
-# spec file
+# spec file for package openSUSE-repos
 #
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2023 SUSE LLC
 # Copyright (c) 2022 Neal Gompa <ngompa13@gmail.com>
 #
 # All modifications and additions to the file contributed by third parties
@@ -77,6 +77,9 @@ Source:         openSUSE-repos-%{version}.tar.xz
 #boo#1203715
 BuildRequires:  -post-build-checks
 Requires:       zypper
+# Ensure we install matching packages on given distribution
+# openSUSE-release has suggest on particular theme based on distribution
+Suggests:       openSUSE-repos-%{theme}-NVIDIA
 Conflicts:      otherproviders(openSUSE-repos)
 Provides:       openSUSE-repos
 %if "%{?theme}" == "Tumbleweed"
@@ -91,9 +94,6 @@ Obsoletes:      openSUSE-repos-LeapMicro
 Obsoletes:      openSUSE-repos-Leap
 Obsoletes:      openSUSE-repos-LeapMicro
 %endif
-# Ensure we install matching packages on given distribution
-# openSUSE-release has suggest on particular theme based on distribution
-Suggests:       openSUSE-repos-%{theme}-NVIDIA
 
 %description
 Definitions for openSUSE repository management via zypp-services
@@ -169,7 +169,7 @@ Definitions for NVIDIA repository management via zypp-services
 %dir %{_datadir}/zypp/local/service/NVIDIA
 %dir %{_datadir}/zypp/local/service/NVIDIA/repo
 %ghost %{_datadir}/zypp/local/service/NVIDIA/repo/repoindex.xml
-/usr/share/zypp/local/service/NVIDIA/repo/nvidia-%{branding}-repoindex.xml
+%{_datadir}/zypp/local/service/NVIDIA/repo/nvidia-%{branding}-repoindex.xml
 %ghost %{_sysconfdir}/zypp/services.d/openSUSE.service
 %{_datadir}/zypp/local/service/NVIDIA/repo/nvidia-%{branding}-repoindex.xml
 %endif

--- a/dist/package/openSUSE-repos.spec
+++ b/dist/package/openSUSE-repos.spec
@@ -101,6 +101,7 @@ Definitions for openSUSE repository management via zypp-services
 %package NVIDIA
 Summary:        openSUSE NVIDIA repository definitions
 Requires:       openSUSE-repos
+Supplements:    modalias(pci:v000010DEd*sv*sd*bc03sc*i*)
 Provides:       openSUSE-repos-NVIDIA
 %if "%{?theme}" == "Tumbleweed"
 Obsoletes:      openSUSE-repos-Leap-NVIDIA

--- a/dist/package/openSUSE-repos.spec
+++ b/dist/package/openSUSE-repos.spec
@@ -102,6 +102,18 @@ Definitions for openSUSE repository management via zypp-services
 Summary:        openSUSE NVIDIA repository definitions
 Requires:       openSUSE-repos
 Provides:       openSUSE-repos-NVIDIA
+%if "%{?theme}" == "Tumbleweed"
+Obsoletes:      openSUSE-repos-Leap-NVIDIA
+Obsoletes:      openSUSE-repos-LeapMicro-NVIDIA
+%endif
+%if "%{?theme}" == "MicroOS"
+Obsoletes:      openSUSE-repos-Leap-NVIDIA
+Obsoletes:      openSUSE-repos-LeapMicro-NVIDIA
+%endif
+%if "%{?theme}" == "Leap16"
+Obsoletes:      openSUSE-repos-Leap-NVIDIA
+Obsoletes:      openSUSE-repos-LeapMicro-NVIDIA
+%endif
 
 %description NVIDIA
 Definitions for NVIDIA repository management via zypp-services

--- a/dist/package/openSUSE-repos.spec
+++ b/dist/package/openSUSE-repos.spec
@@ -91,9 +91,20 @@ Obsoletes:      openSUSE-repos-LeapMicro
 Obsoletes:      openSUSE-repos-Leap
 Obsoletes:      openSUSE-repos-LeapMicro
 %endif
+# Ensure we install matching packages on given distribution
+# openSUSE-release has suggest on particular theme based on distribution
+Suggests:       openSUSE-repos-%{theme}-NVIDIA
 
 %description
 Definitions for openSUSE repository management via zypp-services
+
+%package NVIDIA
+Summary:        openSUSE NVIDIA repository definitions
+Requires:       openSUSE-repos
+Provides:       openSUSE-repos-NVIDIA
+
+%description NVIDIA
+Definitions for NVIDIA repository management via zypp-services
 
 %files
 
@@ -141,6 +152,16 @@ Definitions for openSUSE repository management via zypp-services
 %endif
 %endif
 
+%if "0%{?with_nvidia}"
+%files NVIDIA
+%dir %{_datadir}/zypp/local/service/NVIDIA
+%dir %{_datadir}/zypp/local/service/NVIDIA/repo
+%ghost %{_datadir}/zypp/local/service/NVIDIA/repo/repoindex.xml
+/usr/share/zypp/local/service/NVIDIA/repo/nvidia-%{branding}-repoindex.xml
+%ghost %{_sysconfdir}/zypp/services.d/openSUSE.service
+%{_datadir}/zypp/local/service/NVIDIA/repo/nvidia-%{branding}-repoindex.xml
+%endif
+
 %prep
 %setup -q -n openSUSE-repos-%{version}
 
@@ -150,6 +171,7 @@ Definitions for openSUSE repository management via zypp-services
 %install
 
 mkdir -p %{buildroot}%{_datadir}/zypp/local/service/openSUSE/repo
+mkdir -p %{buildroot}%{_datadir}/zypp/local/service/NVIDIA/repo
 mkdir -p %{buildroot}%{_sysconfdir}/zypp/vars.d/
 
 # Setup for primary arches
@@ -179,6 +201,10 @@ install opensuse-%{branding}-repoindex.xml -pm 0644 %{buildroot}%{_datadir}/zypp
 %else
 install opensuse-%{branding}-ports-repoindex.xml -pm 0644 %{buildroot}%{_datadir}/zypp/local/service/openSUSE/repo
 %endif
+%endif
+
+%if "0%{?with_nvidia}"
+install nvidia-%{branding}-repoindex.xml -pm 0644 %{buildroot}%{_datadir}/zypp/local/service/NVIDIA/repo
 %endif
 
 %ifarch %{ix86}
@@ -242,7 +268,7 @@ ln -sf opensuse-%{branding}-ports-repoindex.xml %{_datadir}/zypp/local/service/o
 %endif
 %endif
 
-# Disable all non-zypp-service managed repos with default fileanmes
+# Disable all non-zypp-service managed repos with default filenames
 
 for repo_file in \
 repo-backports-debug-update.repo repo-oss.repo repo-backports-update.repo \
@@ -261,12 +287,39 @@ done
 # We hereby declare that running this will not influence existing transaction
 ZYPP_READONLY_HACK=1 zypper addservice %{_datadir}/zypp/local/service/openSUSE openSUSE
 
+%if "0%{?with_nvidia}"
+%post NVIDIA
+ln -sf nvidia-%{branding}-repoindex.xml %{_datadir}/zypp/local/service/NVIDIA/repo/repoindex.xml
+
+# Disable user-defined with default filename from wiki
+# https://en.opensuse.org/SDB:NVIDIA_drivers#Zypper
+for repo_file in NVIDIA.repo ; do
+  if [ -f %{_sysconfdir}/zypp/repos.d/$repo_file ]; then
+    echo "Content of $repo_file will be newly managed by zypp-services."
+    echo "Storing old copy as {_sysconfdir}/zypp/repos.d/$repo_file.rpmsave"
+    mv %{_sysconfdir}/zypp/repos.d/$repo_file %{_sysconfdir}/zypp/repos.d/$repo_file.rpmsave
+  fi
+done
+
+# We hereby declare that running this will not influence existing transaction
+ZYPP_READONLY_HACK=1 zypper addservice %{_datadir}/zypp/local/service/NVIDIA NVIDIA
+%endif
+
 %postun
 if [ "$1" = 0 ] ; then
   # We hereby declare that running this will not influence existing transaction
   ZYPP_READONLY_HACK=1 zypper removeservice openSUSE
   if [ -L "%{_datadir}/zypp/local/service/openSUSE/repo/repoindex.xml" ] ; then
     rm -f %{_datadir}/zypp/local/service/openSUSE/repo/repoindex.xml
+  fi
+fi
+
+%postun NVIDIA
+if [ "$1" = 0 ] ; then
+  # We hereby declare that running this will not influence existing transaction
+  ZYPP_READONLY_HACK=1 zypper removeservice NVIDIA
+  if [ -L "%{_datadir}/zypp/local/service/NVIDIA/repo/repoindex.xml" ] ; then
+    rm -f %{_datadir}/zypp/local/service/NVIDIA/repo/repoindex.xml
   fi
 fi
 

--- a/nvidia-leap-repoindex.xml
+++ b/nvidia-leap-repoindex.xml
@@ -1,0 +1,14 @@
+<repoindex ttl="0"
+    disturl="https://download.nvidia.com"
+    distsub="leap/"
+    distver="${releasever}"
+    debugenable="false"
+    sourceenable="false">
+
+<repo url="%{disturl}/opensuse/%{distsub}%{distver}"
+    alias="repo-non-free"
+    name="%{alias} (%{distver})"
+    enabled="true"
+    autorefresh="true"/>
+
+</repoindex>

--- a/nvidia-microos-repoindex.xml
+++ b/nvidia-microos-repoindex.xml
@@ -1,0 +1,13 @@
+<repoindex ttl="0"
+    disturl="https://download.nvidia.com"
+    distsub="tumbleweed/"
+    debugenable="false"
+    sourceenable="false">
+
+<repo url="%{disturl}/opensuse/%{distsub}"
+    alias="repo-non-free"
+    name="%{alias}"
+    enabled="true"
+    autorefresh="true"/>
+
+</repoindex>

--- a/nvidia-tumbleweed-repoindex.xml
+++ b/nvidia-tumbleweed-repoindex.xml
@@ -1,0 +1,13 @@
+<repoindex ttl="0"
+    disturl="https://download.nvidia.com"
+    distsub="tumbleweed/"
+    debugenable="false"
+    sourceenable="false">
+
+<repo url="%{disturl}/opensuse/%{distsub}"
+    alias="repo-non-free"
+    name="%{alias}"
+    enabled="true"
+    autorefresh="true"/>
+
+</repoindex>


### PR DESCRIPTION
* Implements #28 
* Add nvidia repoindexes
* Introduce with_nvidia
* Build it only on i586, x86_64, aarch64 (limit is 3rd party repo availability)
* Ensure that migration from Leap 15.X / LeapMicro to TW/MicroOS/Leap16 works as expected
* Provide hw Supplements for all NVIDIA cards