### PR TITLE
Revert back to https:// for cdn.opensuse.org

### DIFF
--- a/opensuse-leap-micro-repoindex.xml
+++ b/opensuse-leap-micro-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="leap-micro/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap-ports-repoindex.xml
+++ b/opensuse-leap-ports-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap-repoindex.xml
+++ b/opensuse-leap-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-microos-repoindex.xml
+++ b/opensuse-microos-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="tumbleweed/"
     debugenable="false"
     sourceenable="false">

--- a/opensuse-tumbleweed-repoindex.xml
+++ b/opensuse-tumbleweed-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="https://cdn.opensuse.org"
     distsub="tumbleweed/"
     debugenable="false"
     sourceenable="false">


### PR DESCRIPTION
* Complains regarding slow repodata downloads
* Namely https://code.opensuse.org/leap/features/issue/128#comment-1842