### PR TITLE
Allow user to use a custom disturl

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ $ zypper ref -s # optionally force refresh services
 Repositories managed by zypp-services can be easily identified as they will have openSUSE: prefix (or any other that you have chosen).
 ```
 
+## Overriding the default url
+
+openSUSE repoindex file defines default disturl for repositories under the openSUSE service
+```disturl="${OPENSUSE_DISTURL:-http://cdn.opensuse.org}"```
+
+This default can be simply overridden to point to a particular mirror by defining **OPENSUSE_DISTURL** zypp variable.
+
+```
+# echo "https://my-mirror.org" > /etc/zypp/vars.d/OPENSUSE_DISTURL
+```
+
+You can fall back again to the default dist url by
+
+```
+# rm /etc/zypp/vars.d/OPENSUSE_DISTURL
+
+```
 
 ## Restoring original distribution repositories
 openSUSE-repos does backup of all existing  default distribution repo files under /etc/zypp/repos.d/*.rpmsave

--- a/dist/package/openSUSE-repos.spec
+++ b/dist/package/openSUSE-repos.spec
@@ -136,6 +136,9 @@ Definitions for NVIDIA repository management via zypp-services
 %ghost %{_datadir}/zypp/local/service/openSUSE/repo/repoindex.xml
 %ghost %{_sysconfdir}/zypp/services.d/openSUSE.service
 %{_sysconfdir}/zypp/vars.d/DIST_ARCH
+# Overriding the default OPENSUSE_DISTURL allows a direct mirror enablement
+# We've agreed that the variable/file will not be created by default. See PR#42
+%ghost %{_sysconfdir}/zypp/vars.d/OPENSUSE_DISTURL
 
 %if "%{theme}" == "Tumbleweed"
 %ifarch %{ix86} x86_64

--- a/opensuse-leap-micro-repoindex.xml
+++ b/opensuse-leap-micro-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="${OPENSUSE_DISTURL:-http://cdn.opensuse.org}"
     distsub="leap-micro/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap-ports-repoindex.xml
+++ b/opensuse-leap-ports-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="${OPENSUSE_DISTURL:-http://cdn.opensuse.org}"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap-repoindex.xml
+++ b/opensuse-leap-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="${OPENSUSE_DISTURL:-http://cdn.opensuse.org}"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="${OPENSUSE_DISTURL:-http://cdn.opensuse.org}"
     distsub="leap/"
     distver="${releasever}"
     debugenable="false"

--- a/opensuse-microos-repoindex.xml
+++ b/opensuse-microos-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="${OPENSUSE_DISTURL:-http://cdn.opensuse.org}"
     distsub="tumbleweed/"
     debugenable="false"
     sourceenable="false">

--- a/opensuse-tumbleweed-repoindex.xml
+++ b/opensuse-tumbleweed-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="http://cdn.opensuse.org"
+    disturl="${OPENSUSE_DISTURL:-http://cdn.opensuse.org}"
     distsub="tumbleweed/"
     debugenable="false"
     sourceenable="false">


### PR DESCRIPTION
* This allows a direct mirror enablement without a need to install openSUSE-repos package.

* I struggled a bit whether to set variable in /etc or not since we have a default in repoindex. Creating the file makes it an easier edit as he simply needs to edit an existing file rather than creating a new file based on the manual etc.