### PR TITLE
deleted an extra slash in the repository files

### DIFF
--- a/nvidia-leap-repoindex.xml
+++ b/nvidia-leap-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="https://download.nvidia.com"
-    distsub="leap/"
+    distsub="leap"
     distver="${releasever}"
     debugenable="false"
     sourceenable="false">

--- a/nvidia-microos-repoindex.xml
+++ b/nvidia-microos-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="https://download.nvidia.com"
-    distsub="tumbleweed/"
+    distsub="tumbleweed"
     debugenable="false"
     sourceenable="false">
 

--- a/nvidia-tumbleweed-repoindex.xml
+++ b/nvidia-tumbleweed-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="https://download.nvidia.com"
-    distsub="tumbleweed/"
+    distsub="tumbleweed"
     debugenable="false"
     sourceenable="false">
 

--- a/opensuse-leap-micro-repoindex.xml
+++ b/opensuse-leap-micro-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="http://cdn.opensuse.org"
-    distsub="leap-micro/"
+    distsub="leap-micro"
     distver="${releasever}"
     debugenable="false"
     sourceenable="false">

--- a/opensuse-leap-ports-repoindex.xml
+++ b/opensuse-leap-ports-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="http://cdn.opensuse.org"
-    distsub="leap/"
+    distsub="leap"
     distver="${releasever}"
     debugenable="false"
     sourceenable="false">

--- a/opensuse-leap-repoindex.xml
+++ b/opensuse-leap-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="http://cdn.opensuse.org"
-    distsub="leap/"
+    distsub="leap"
     distver="${releasever}"
     debugenable="false"
     sourceenable="false">

--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="http://cdn.opensuse.org"
-    distsub="leap/"
+    distsub="leap"
     distver="${releasever}"
     debugenable="false"
     sourceenable="false">

--- a/opensuse-microos-repoindex.xml
+++ b/opensuse-microos-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="http://cdn.opensuse.org"
-    distsub="tumbleweed/"
+    distsub="tumbleweed"
     debugenable="false"
     sourceenable="false">
 

--- a/opensuse-tumbleweed-ports-repoindex.xml
+++ b/opensuse-tumbleweed-ports-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="https://download.opensuse.org"
-    distsub="tumbleweed/"
+    distsub="tumbleweed"
     debugenable="false"
     sourceenable="false">
 

--- a/opensuse-tumbleweed-repoindex.xml
+++ b/opensuse-tumbleweed-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="http://cdn.opensuse.org"
-    distsub="tumbleweed/"
+    distsub="tumbleweed"
     debugenable="false"
     sourceenable="false">
 


### PR DESCRIPTION
Deleted the extra slashes in the repository files. Because they are duplicated in the repos URLs.