### PR TITLE
remove an extra slash in 'nvidia-slowroll-repoindex.xml' file

### DIFF
--- a/nvidia-slowroll-repoindex.xml
+++ b/nvidia-slowroll-repoindex.xml
@@ -1,6 +1,6 @@
 <repoindex ttl="0"
     disturl="https://download.nvidia.com"
-    distsub="tumbleweed/"
+    distsub="tumbleweed"
     debugenable="false"
     sourceenable="false">
 


### PR DESCRIPTION
You added an extra slash to the file nvidia-slowroll-repoindex.xml