### PR TITLE
Fixes for Tumbleweed ports

### DIFF
--- a/opensuse-tumbleweed-ports-repoindex.xml
+++ b/opensuse-tumbleweed-ports-repoindex.xml
@@ -13,13 +13,13 @@
 <repo url="%{disturl}/ports/$DIST_ARCH/debug/%{distsub}/repo/oss"
     alias="repo-oss-debug"
     name="%{alias}"
-    enabled="true"
+    enabled="false"
     autorefresh="true"/>
 
 <repo url="%{disturl}/ports/$DIST_ARCH/source/%{distsub}/repo/oss"
     alias="repo-oss-source"
     name="%{alias}"
-    enabled="true"
+    enabled="false"
     autorefresh="true"/>
 
 <repo url="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"

--- a/opensuse-tumbleweed-ports-repoindex.xml
+++ b/opensuse-tumbleweed-ports-repoindex.xml
@@ -1,5 +1,5 @@
 <repoindex ttl="0"
-    disturl="https://download.opensuse.org"
+    disturl="http://cdn.opensuse.org"
     distsub="tumbleweed"
     debugenable="false"
     sourceenable="false">


### PR DESCRIPTION
* Swicth from download.opensuse.org to cdn.opensuse.org for Tumbleweed ports
* Disable debug/source repos by default for Tumbleweed ports