### PR TITLE
Working Leap 16 repoindex with standard + product repo

### DIFF
--- a/checks/repo_checks
+++ b/checks/repo_checks
@@ -16,8 +16,13 @@ for path in ${CURRDIR}/../*.xml; do
     export distarch="zsystems" # we expect s390x to be around
     # Manually managed in the test
     if [ "$distsub" == "leap" ]; then
-        export distver="15.5" # Should be bumped periodically
-        export distarch="armv7hl" # we expect s390x to be around
+        if [[ $filename == *"leap16"* ]]; then
+            export distver="16.0" # Should be bumped periodically
+            export distarch="x86_64"
+        else
+            export distver="15.5" # Should be bumped periodically
+            export distarch="armv7hl" # we expect s390x to be around
+        fi
     fi
     if [ "$distsub" == "leap-micro" ]; then
         if [[ $filename == *"leap-micro6"* ]]; then

--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -6,9 +6,27 @@
     sourceenable="false">
 
 <repo url="%{disturl}/repositories/openSUSE:/Leap:/16.0/standard/
-    alias="repo-oss"
-    name="%{alias} (16.0)"
+    alias="repo-standard"
+    name="%{alias} (%{distver})"
     enabled="true"
+    autorefresh="true"/>
+
+<repo url="%{disturl}/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-$DIST_ARCH"
+    alias="repo-oss"
+    name="%{alias} (%{distver})"
+    enabled="true"
+    autorefresh="true"/>
+
+<repo url="%{disturl}/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-$DIST_ARCH-Debug"
+    alias="repo-oss-debug"
+    name="%{alias} (%{distver})"
+    enabled="false"
+    autorefresh="true"/>
+
+<repo url="%{disturl}/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-$DIST_ARCH-Source"
+    alias="repo-oss-source"
+    name="%{alias} (%{distver})"
+    enabled="false"
     autorefresh="true"/>
 
 </repoindex>


### PR DESCRIPTION
Same repository set as for https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0:/Images/images/iso/

- for now let's skip v3 repositories and other non-default repos that are not on all arches