### PR TITLE
Changing opensuse-leap16-repoindex.xml to distribution instead of repositories

### DIFF
--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -11,7 +11,7 @@
     enabled="true"
     autorefresh="true"/>
 
-<repo url="%{disturl}/distribution/leap/16.0/repo/oss"
+<repo url="%{disturl}/distribution/leap/%{distver}/repo/oss"
     alias="repo-oss"
     name="%{alias} (%{distver})"
     enabled="true"

--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -23,7 +23,7 @@
     enabled="false"
     autorefresh="true"/>
 
-<repo url="%{disturl}/source/distribution/leap/16.0/repo/oss"
+<repo url="%{disturl}/source/distribution/leap/%{distver}/repo/oss"
     alias="repo-oss-source"
     name="%{alias} (%{distver})"
     enabled="false"

--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -11,19 +11,19 @@
     enabled="true"
     autorefresh="true"/>
 
-<repo url="%{disturl}/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-$DIST_ARCH"
+<repo url="%{disturl}/distribution/leap/16.0/repo/oss"
     alias="repo-oss"
     name="%{alias} (%{distver})"
     enabled="true"
     autorefresh="true"/>
 
-<repo url="%{disturl}/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-$DIST_ARCH-Debug"
+<repo url="%{disturl}/debug/distribution/leap/16.0/repo/oss"
     alias="repo-oss-debug"
     name="%{alias} (%{distver})"
     enabled="false"
     autorefresh="true"/>
 
-<repo url="%{disturl}/repositories/openSUSE:/Leap:/16.0/product/repo/Leap-Packages-16.0-$DIST_ARCH-Source"
+<repo url="%{disturl}/source/distribution/leap/16.0/repo/oss"
     alias="repo-oss-source"
     name="%{alias} (%{distver})"
     enabled="false"

--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -17,7 +17,7 @@
     enabled="true"
     autorefresh="true"/>
 
-<repo url="%{disturl}/debug/distribution/leap/16.0/repo/oss"
+<repo url="%{disturl}/debug/distribution/leap/%{distver}/repo/oss"
     alias="repo-oss-debug"
     name="%{alias} (%{distver})"
     enabled="false"


### PR DESCRIPTION
Changing opensuse-leap16-repoindex.xml to distribution instead of repositories