### PR TITLE
Add openh264 repo for Leap 16.0

### DIFF
--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -23,4 +23,10 @@
     enabled="false"
     autorefresh="true"/>
 
+<repo url="http://codecs.opensuse.org/openh264/openSUSE_Leap_16"
+    alias="repo-openh264"
+    name="%{alias} (%{distver})"
+    enabled="true"
+    autorefresh="true"/>
+
 </repoindex>


### PR DESCRIPTION
The path doesn't exist yet in http://codecs.opensuse.org/openh264/ but the repo was already created in OBS https://build.opensuse.org/package/show/openSUSE:Factory:openh264/openh264

Let's wait until the CI is green,  which requires manual steps from @lkocman, once cisco extracted the tarball with rpms that we sent them today. Details at https://en.opensuse.org/OpenH264#Manual_publishing_workflow

