### PR TITLE
Add non-oss / non-oss-debug repos for Leap 16.0

### DIFF
--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -23,6 +23,18 @@
     enabled="false"
     autorefresh="true"/>
 
+<repo url="%{disturl}/distribution/leap/%{distver}/repo/non-oss/$basearch?mediahandler=curl2"
+    alias="repo-non-oss"
+    name="%{alias} (%{distver})"
+    enabled="false"
+    autorefresh="true"/>
+
+<repo url="%{disturl}/debug/distribution/leap/%{distver}/repo/non-oss/$basearch?mediahandler=curl2"
+    alias="repo-non-oss-debug"
+    name="%{alias} (%{distver})"
+    enabled="false"
+    autorefresh="true"/>
+
 <repo url="http://codecs.opensuse.org/openh264/openSUSE_Leap_16"
     alias="repo-openh264"
     name="%{alias} (%{distver})"


### PR DESCRIPTION
Both urls now exist

https://download.opensuse.org/debug/distribution/leap/16.0/repo/non-oss/
https://download.opensuse.org/distribution/leap/16.0/repo/non-oss/