### PR TITLE
Drop opensuse_repos.sh

### DIFF
--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -46,6 +46,7 @@
     autorefresh="true"/>
 
 <repo url="http://codecs.opensuse.org/openh264/openSUSE_Leap_16"
+    gpgkey="https://codecs.opensuse.org/openh264/openSUSE_Leap_16/repodata/repomd.xml.key"
     alias="repo-openh264"
     name="%{alias} (%{distver})"
     enabled="true"

--- a/opensuse-tumbleweed-ports-repoindex.xml
+++ b/opensuse-tumbleweed-ports-repoindex.xml
@@ -45,6 +45,7 @@
     autorefresh="true"/>
 
 <repo url="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"
+    gpgkey="https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed/repodata/repomd.xml.key"
     alias="repo-openh264"
     name="%{alias}"
     enabled="true"

--- a/opensuse-tumbleweed-repoindex.xml
+++ b/opensuse-tumbleweed-repoindex.xml
@@ -37,6 +37,7 @@
     autorefresh="true"/>
 
 <repo url="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"
+    gpgkey="https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed/repodata/repomd.xml.key"
     alias="repo-openh264"
     name="%{alias}"
     enabled="true"

--- a/opensuse_repos.sh
+++ b/opensuse_repos.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Intended to be placed in /etc/profile.d/
-
-# https://github.com/openSUSE/openSUSE-repos/issues/78
-export ZYPP_PCK_PRELOAD=1


### PR DESCRIPTION
* no longer needed as zypp parallel defaults are now enabled by default