### PR TITLE
Use https for openh264 poo#185650

### DIFF
--- a/opensuse-leap-ports-repoindex.xml
+++ b/opensuse-leap-ports-repoindex.xml
@@ -17,7 +17,7 @@
     enabled="false"
     autorefresh="true"/>
 
-<repo url="http://codecs.opensuse.org/openh264/openSUSE_Leap?mediahandler=curl2"
+<repo url="https://codecs.opensuse.org/openh264/openSUSE_Leap?mediahandler=curl2"
     alias="repo-openh264"
     name="%{alias} (%{distver})"
     enabled="true"

--- a/opensuse-leap-repoindex.xml
+++ b/opensuse-leap-repoindex.xml
@@ -35,7 +35,7 @@
     enabled="false"
     autorefresh="true"/>
 
-<repo url="http://codecs.opensuse.org/openh264/openSUSE_Leap?mediahandler=curl2"
+<repo url="https://codecs.opensuse.org/openh264/openSUSE_Leap?mediahandler=curl2"
     alias="repo-openh264"
     name="%{alias} (%{distver})"
     enabled="true"

--- a/opensuse-leap16-repoindex.xml
+++ b/opensuse-leap16-repoindex.xml
@@ -40,7 +40,7 @@
     enabled="false"
     autorefresh="true"/>
 
-<repo url="http://codecs.opensuse.org/openh264/openSUSE_Leap_16"
+<repo url="https://codecs.opensuse.org/openh264/openSUSE_Leap_16"
     gpgkey="https://codecs.opensuse.org/openh264/openSUSE_Leap_16/repodata/repomd.xml.key"
     alias="repo-openh264"
     name="%{alias} (%{distver})"

--- a/opensuse-microos-repoindex.xml
+++ b/opensuse-microos-repoindex.xml
@@ -28,7 +28,7 @@
     enabled="true"
     autorefresh="true"/>
 
-<repo url="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"
+<repo url="https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"
     alias="repo-openh264"
     name="%{alias}"
     enabled="true"

--- a/opensuse-slowroll-repoindex.xml
+++ b/opensuse-slowroll-repoindex.xml
@@ -28,7 +28,7 @@
     enabled="true"
     autorefresh="true"/>
 
-<repo url="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"
+<repo url="https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"
     alias="repo-openh264"
     name="%{alias}"
     enabled="true"

--- a/opensuse-tumbleweed-ports-repoindex.xml
+++ b/opensuse-tumbleweed-ports-repoindex.xml
@@ -39,7 +39,7 @@
     enabled="false"
     autorefresh="true"/>
 
-<repo url="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"
+<repo url="https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"
     gpgkey="https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed/repodata/repomd.xml.key"
     alias="repo-openh264"
     name="%{alias}"

--- a/opensuse-tumbleweed-repoindex.xml
+++ b/opensuse-tumbleweed-repoindex.xml
@@ -32,7 +32,7 @@
     enabled="true"
     autorefresh="true"/>
 
-<repo url="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"
+<repo url="https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"
     gpgkey="https://codecs.opensuse.org/openh264/openSUSE_Tumbleweed/repodata/repomd.xml.key"
     alias="repo-openh264"
     name="%{alias}"


### PR DESCRIPTION
Cisco started using AWS for ciscobinary.openh264 last Friday. SSL setup is finally working.